### PR TITLE
facetted search on integer keys

### DIFF
--- a/lib/ultrasphinx/search/internals.rb
+++ b/lib/ultrasphinx/search/internals.rb
@@ -158,7 +158,7 @@ module Ultrasphinx
         request, facet = original_request._deep_dup, original_facet        
         facet += "_facet" if Fields.instance.types[original_facet] == 'text'            
         
-        unless Fields.instance.types[facet]
+        if Fields.instance.types[facet].nil?
           if facet == original_facet
             raise UsageError, "Field #{original_facet} does not exist" 
           else


### PR DESCRIPTION
I wasn't able to get a facetted search to work on an integer key from one of my indexed objects. It looked like it should be valid to me and indeed, just changing the conditions that raise the error worked for me. 

-thanks for the hard work

?> p search_hash = {:query => 'neur', :class_names => 'SearchableCondition', :per_page => 1000, :page =>1, :excerpt => true, :facets => :condition_id }
{:excerpt=>true, :facets=>:condition_id, :per_page=>1000, :page=>1, :class_names=>"SearchableCondition", :query=>"neur"}

=> nil

> > ```
> > Ultrasphinx::Search.new(search_hash).run.facets
> > ```
> > 
> > Ultrasphinx::UsageError: Field condition_id does not exist
> >     from /Users/jdwyah/workspace/plm-website/.bundle/ruby/1.8/gems/ultrasphinx-1.11/lib/ultrasphinx/search/internals.rb:163:in `get_facets'
